### PR TITLE
Fixed a "pageTags" possible error, updated node modules, updated jQuery

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "TODO",
   "version": "0.0.0",
   "devDependencies": {
-    "jquery":           "2.2.0",
+    "jquery":           "2.2.1",
     "pubsub-js":        "1.5.3",
     "fastclick":        "1.0.6",
     "foundation-sites": "6.1.2",

--- a/components/nwayo/scripts/dependencies-starter.js
+++ b/components/nwayo/scripts/dependencies-starter.js
@@ -52,16 +52,19 @@
 	let path = konstan.konstan.path;
 	delete konstan.konstan.path;
 
+	let culture = $('html').attr('lang');
+	let $body = $('body');
+	let bodyClass = $body.attr('class');
 	addProp(global, konstan.project, readonlyObj({
 		bundle:  konstan.bundle,
 		konstan: konstan.konstan,
 		path:    path,
 		tmpl:    {},
 		env:     {
-			culture:  $('html').attr('lang'),
-			lang:     $('html').attr('lang').substr(0,2),
-			pageId:   $('body').attr('id'),
-			pageTags: _.compact( $('body').attr('class').split(' ') )
+			culture:  culture,
+			lang:     culture.substr(0,2),
+			pageId:   $body.attr('id'),
+			pageTags: !!bodyClass ? _.compact( $('body').attr('class').split(' ') ) : []
 		}
 	}));
 

--- a/components/nwayo/scripts/dependencies-starter.js
+++ b/components/nwayo/scripts/dependencies-starter.js
@@ -64,7 +64,7 @@
 			culture:  culture,
 			lang:     culture.substr(0,2),
 			pageId:   $body.attr('id'),
-			pageTags: !!bodyClass ? _.compact( $('body').attr('class').split(' ') ) : []
+			pageTags: !!bodyClass ? _.compact( bodyClass.split(' ') ) : []
 		}
 	}));
 

--- a/package.json
+++ b/package.json
@@ -11,16 +11,16 @@
   "devDependencies": {
     "fs-extra": "0.26.5",
     "del":      "2.2.0",
-    "glob":     "6.0.4",
-    "js-yaml":  "3.5.2",
-    "inquirer": "0.11.4",
+    "glob":     "7.0.0",
+    "js-yaml":  "3.5.3",
+    "inquirer": "0.12.0",
     "async":    "1.5.2",
     "minimist": "1.2.0",
     "colors":   "1.1.2",
     "crypto":   "0.0.3",
-    "lodash":   "4.2.0",
+    "lodash":   "4.5.1",
 
-    "gulp":         "3.9.0",
+    "gulp":         "3.9.1",
     "gulp-debug":   "2.1.2",
     "gulp-cached":  "1.1.0",
     "gulp-rename":  "1.2.2",
@@ -35,20 +35,20 @@
     "gulp-scss-lint":    "0.3.9",
     "gulp-ruby-sass":    "2.0.6",
     "gulp-autoprefixer": "3.1.0",
-    "gulp-cssnano":      "2.1.0",
+    "gulp-cssnano":      "2.1.1",
     "gulp-json-sass":    "0.0.2",
 
     "jshint":              "2.9.1",
-    "jscs":                "2.9.0",
+    "jscs":                "2.10.1",
     "gulp-jshint":         "2.0.0",
     "gulp-jscs":           "3.0.2",
     "gulp-jscs-stylish":   "1.3.0",
     "gulp-nwayo-include":  "0.3.0",
-    "babel-core":          "6.4.5",
-    "babel-preset-es2015": "6.3.13",
-    "gulp-uglify":         "1.5.1",
+    "babel-core":          "6.6.0",
+    "babel-preset-es2015": "6.6.0",
+    "gulp-uglify":         "1.5.3",
 
     "modernizr":  "3.3.1",
-    "lodash-cli": "4.2.0"
+    "lodash-cli": "4.5.1"
   }
 }


### PR DESCRIPTION
Fixed environment variable "pageTags" which caused an error if the "body" did not have a "class" attribute.
Updated node modules.
Updated jQuery to  version 2.2.1.
